### PR TITLE
Prefix mkincl targets with with mkincl

### DIFF
--- a/.mkincl/init.mk
+++ b/.mkincl/init.mk
@@ -1,8 +1,8 @@
 MKINCL_DIR ?= .mkincl
 INITS = $(wildcard $(MKINCL_DIR)/inits/*)
 
-.PHONY: mkincl-init $(INITS)
-mkincl-init: mkincl-clean $(INITS)
+.PHONY: init-mkincl $(INITS)
+init-mkincl: clean-mkincl $(INITS)
 $(INITS):
 	@echo -- Initializing provider $@
 	. $(realpath $@) \
@@ -10,8 +10,8 @@ $(INITS):
 	&& git clone --quiet $$URL $(MKINCL_DIR)/providers/$$NAME \
 	&& git -C $(MKINCL_DIR)/providers/$$NAME reset --quiet --hard $$VERSION
 
-.PHONY: mkincl-clean
-mkincl-clean:
+.PHONY: clean-mkincl
+clean-mkincl:
 	rm -rf $(MKINCL_DIR)/providers
 
 -include $(MKINCL_DIR)/providers/*/include.mk

--- a/.mkincl/init.mk
+++ b/.mkincl/init.mk
@@ -1,8 +1,8 @@
 MKINCL_DIR ?= .mkincl
 INITS = $(wildcard $(MKINCL_DIR)/inits/*)
 
-.PHONY: init $(INITS)
-init: clean $(INITS)
+.PHONY: mkincl-init $(INITS)
+mkincl-init: mkincl-clean $(INITS)
 $(INITS):
 	@echo -- Initializing provider $@
 	. $(realpath $@) \
@@ -10,8 +10,8 @@ $(INITS):
 	&& git clone --quiet $$URL $(MKINCL_DIR)/providers/$$NAME \
 	&& git -C $(MKINCL_DIR)/providers/$$NAME reset --quiet --hard $$VERSION
 
-.PHONY: clean
-clean:
+.PHONY: mkincl-clean
+mkincl-clean:
 	rm -rf $(MKINCL_DIR)/providers
 
 -include $(MKINCL_DIR)/providers/*/include.mk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.16
+FROM alpine:3.18
 
 RUN apk add --no-cache \
-    git=2.36.1-r0 \
-    make=4.3-r0
+    git=2.40.1-r0 \
+    make=4.4.1-r1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The minimum requirement for a provider is that it contains the Makefile
 
 A user must contain three things:
 
-1. The Makefile that contains the `mkincl-clean` and `mkincl-init` targets:
+1. The Makefile that contains the `clean-mkincl` and `init-mkincl` targets:
    [`.mkincl/init.mk`](.mkincl/init.mk). This file is completely generic and
    can be copied without modifications to new repositories.
 
@@ -56,16 +56,16 @@ checking out a project two targets are available:
 
 ```sh
 $ make <tab><tab>
-mkincl-clean mkincl-init
+clean-mkincl init-mkincl
 ```
 
-When running the `mkincl-init` target, target providers will be fetched and
+When running the `init-mkincl` target, target providers will be fetched and
 after that all their targets will now be available:
 
 ```sh
-$ make mkincl-init --silent
+$ make init-mkincl --silent
 $ make <tab><tab>
-mkincl-clean            fix-mkincl              mkincl-init             lint-mkincl-linter1
+clean-mkincl            fix-mkincl              init-mkincl             lint-mkincl-linter1
 enter-mkincl-container  fix-mkincl-fixer1       lint                    lint-mkincl-linter2
 fix                     fix-mkincl-fixer2       lint-mkincl
 ```
@@ -124,7 +124,7 @@ jobs:
     container: ghcr.io/mkincl/shell-provider:v1
     steps:
       - uses: actions/checkout@v2
-      - run: make mkincl-init
+      - run: make init-mkincl
       - run: make lint-shell
 ```
 
@@ -134,7 +134,7 @@ This job is trivial to adapt for GitLab CI:
 lint-shell:
   image: ghcr.io/mkincl/shell-provider:v1
   script:
-    - make init
+    - make init-mkincl
     - make lint-shell
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This reduced copy-pasted configuration and inconsistent practices across
 projects, but was difficult to run locally and resulted too much code in YAML
 files for my taste.
 
-_mkincl_ is an alternative approach which addresses these pain points, by relying
-on Makefiles. It provides a centralized and standardized interface to
+_mkincl_ is an alternative approach which addresses these pain points, by
+relying on Makefiles. It provides a centralized and standardized interface to
 development tools and processes while having a small footprint.
 
 ### Why Makefiles?
@@ -37,7 +37,7 @@ The minimum requirement for a provider is that it contains the Makefile
 
 A user must contain three things:
 
-1. The Makefile that contains the `clean` and `init` targets:
+1. The Makefile that contains the `mkincl-clean` and `mkincl-init` targets:
    [`.mkincl/init.mk`](.mkincl/init.mk). This file is completely generic and
    can be copied without modifications to new repositories.
 
@@ -56,16 +56,16 @@ checking out a project two targets are available:
 
 ```sh
 $ make <tab><tab>
-clean init
+mkincl-clean mkincl-init
 ```
 
-When running the `init` target, target providers will be fetched and after that
-all their targets will now be available:
+When running the `mkincl-init` target, target providers will be fetched and
+after that all their targets will now be available:
 
 ```sh
-$ make init --silent
+$ make mkincl-init --silent
 $ make <tab><tab>
-clean                   fix-mkincl              init                    lint-mkincl-linter1
+mkincl-clean            fix-mkincl              mkincl-init             lint-mkincl-linter1
 enter-mkincl-container  fix-mkincl-fixer1       lint                    lint-mkincl-linter2
 fix                     fix-mkincl-fixer2       lint-mkincl
 ```
@@ -124,7 +124,7 @@ jobs:
     container: ghcr.io/mkincl/shell-provider:v1
     steps:
       - uses: actions/checkout@v2
-      - run: make init
+      - run: make mkincl-init
       - run: make lint-shell
 ```
 


### PR DESCRIPTION
The generic targets `init` and `clean` are bound to experience conflicts
with user Makefiles. As such, rename the targets in `.mkincl/init.mk` to
`mkincl-init` and `mkincl-clean`.

An example of where the past names were problematic: If a user
repository defines a target named `clean` that does removes arbitrary
directory, this target will shadow mkincl's `clean` target which will
break the `init` target:

    $ make init
    Makefile:4: warning: overriding recipe for target 'clean'
    .mkincl/init.mk:15: warning: ignoring old recipe for target 'clean'
    echo hello
    hello
    -- Initializing provider .mkincl/inits/shell.sh
    . /home/carsme/repos/git.got.jeppesensystems.com/fpc/cloud/shfpxclient/.mkincl/inits/shell.sh \
    && mkdir -p .mkincl/providers \
    && git clone --quiet $URL .mkincl/providers/$NAME \
    && git -C .mkincl/providers/$NAME reset --quiet --hard $VERSION
    fatal: destination path '.mkincl/providers/shell' already exists and is not an empty directory.
    make: *** [.mkincl/init.mk:8: .mkincl/inits/shell.sh] Error 128